### PR TITLE
Added automatic attachment to the Spelunky 2 process instead of requi…

### DIFF
--- a/JesterCap/App.config
+++ b/JesterCap/App.config
@@ -1,9 +1,22 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
-    </startup>
-	<appSettings>
-		<add key="warningTimes" value="5, 2.5, 1"/>
-	</appSettings>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+  </startup>
+  <appSettings>
+    <add key="warningTimes" value="5, 2.5, 1" />
+    <add key="ClientSettingsProvider.ServiceUri" value="" />
+  </appSettings>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
+      </providers>
+    </roleManager>
+  </system.web>
 </configuration>

--- a/JesterCap/JesterCap.csproj
+++ b/JesterCap/JesterCap.csproj
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -58,6 +59,8 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Management" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />

--- a/JesterCap/MainWindow.xaml
+++ b/JesterCap/MainWindow.xaml
@@ -20,9 +20,9 @@
 
         <Border x:Name="PanelAttach" Grid.Column="0" Grid.Row="0" Background="#88000000">
             <Grid>
-                <Label HorizontalAlignment="Center" VerticalAlignment="Top" Padding="5,3,5,3" Margin="0,10,0,10" Foreground="White">Attach to Process</Label>
+                <Label HorizontalAlignment="Center" VerticalAlignment="Top" Padding="5,3,5,3" Margin="0,10,0,10" Foreground="White">Start Spelunky 2</Label>
                 <Image x:Name="IconAttach" HorizontalAlignment="Center" VerticalAlignment="Center" Source="Resources/spelunky_2_shadow.png" Width="64"></Image>
-                <Button x:Name="ButtonAttach" HorizontalAlignment="Center" VerticalAlignment="Bottom" Padding="5,3,5,3" Margin="0,10,0,10" Click="ButtonAttach_Click">Attach</Button>
+                <!--<Button x:Name="ButtonAttach" HorizontalAlignment="Center" VerticalAlignment="Bottom" Padding="5,3,5,3" Margin="0,10,0,10" Click="ButtonAttach_Click">Attach</Button>-->
             </Grid>
         </Border>
 

--- a/JesterCap/MainWindow.xaml.cs
+++ b/JesterCap/MainWindow.xaml.cs
@@ -30,29 +30,43 @@ namespace JesterCap
         {
             InitializeComponent();
             timer = new TimerLogic(this);
+            ProcessSearcher.StartSearchingForSpelunkyProcess(OnSpelunkyProcessFound);
 
             SetActivePanelAttach(activePanelAttach);
             SetActivePanelReader(activePanelReader);
             SetActivePanelTimer(activePanelTimer);
         }
 
-        private void ButtonAttach_Click(object sender, RoutedEventArgs e)
+        private void OnSpelunkyProcessFound(Process spelunkyProcess)
         {
-            Process spelunkyProcess = ProcessSearcher.SearchForSpelunkyProcess();
-            if (spelunkyProcess == null)
-            {
-                MessageBox.Show(string.Format("Process \"{0}\" not found. Please try again.", ProcessSearcher.SPELUNKY_PROCESS_NAME), "Process Not Found", MessageBoxButton.OK, MessageBoxImage.Warning);
-                return;
-            }
-
             ProcessReader.LoadProcess(spelunkyProcess);
             spelunkyProcess.EnableRaisingEvents = true;
             spelunkyProcess.Exited += SpelunkyProcess_Exited;
 
-            SetActivePanelAttach(false);
-            SetActivePanelReader(true);
+            Dispatcher.Invoke(() => {
+                SetActivePanelAttach(false);
+                SetActivePanelReader(true);
+            });
             timer.Start();
         }
+
+        //private void ButtonAttach_Click(object sender, RoutedEventArgs e)
+        //{
+        //    Process spelunkyProcess = ProcessSearcher.GetSpelunkyProcess();
+        //    if (spelunkyProcess == null)
+        //    {
+        //        MessageBox.Show(string.Format("Process \"{0}\" not found. Please try again.", ProcessSearcher.SPELUNKY_PROCESS_NAME), "Process Not Found", MessageBoxButton.OK, MessageBoxImage.Warning);
+        //        return;
+        //    }
+
+        //    ProcessReader.LoadProcess(spelunkyProcess);
+        //    spelunkyProcess.EnableRaisingEvents = true;
+        //    spelunkyProcess.Exited += SpelunkyProcess_Exited;
+
+        //    SetActivePanelAttach(false);
+        //    SetActivePanelReader(true);
+        //    timer.Start();
+        //}
 
         private void SpelunkyProcess_Exited(object sender, EventArgs e)
         {
@@ -81,8 +95,8 @@ namespace JesterCap
 
             PanelAttach.Background = CreateBrush(active ? COLOR_PANEL_BG_ACTIVE : COLOR_PANEL_BG_INACTIVE);
             IconAttach.Source = CreateImageSource(active ? ICON_ATTACH_ACTIVE : ICON_ATTACH_INACTIVE);
-            ButtonAttach.IsEnabled = active;
-            ButtonAttach.Content = active ? "Attach" : "Attached";
+            //ButtonAttach.IsEnabled = active;
+            //ButtonAttach.Content = active ? "Attach" : "Attached";
         }
 
         public void SetActivePanelReader(bool active)

--- a/JesterCap/ProcessSearcher.cs
+++ b/JesterCap/ProcessSearcher.cs
@@ -3,7 +3,10 @@
  * to it.
  */
 
+using System;
 using System.Diagnostics;
+using System.Management;
+using System.Timers;
 
 namespace JesterCap
 {
@@ -11,7 +14,53 @@ namespace JesterCap
     {
         public const string SPELUNKY_PROCESS_NAME = "Spel2";
 
-        public static Process SearchForSpelunkyProcess()
+        private const int PROCESS_SEARCH_INTERVAL_MS = 5000;
+
+        public static void StartSearchingForSpelunkyProcess(Action<Process> processFound)
+        {
+            Process spelunkyProcess;
+            try
+            {
+                spelunkyProcess = TryGetSpelunkyProcess();
+                if (spelunkyProcess != null)
+                {
+                    processFound(spelunkyProcess);
+                    return;
+                }
+
+                ManagementEventWatcher processCreationWatcher = new ManagementEventWatcher("SELECT * FROM Win32_ProcessStartTrace");
+                processCreationWatcher.EventArrived += new EventArrivedEventHandler((sender, e) =>
+                {
+                    if ((string)e.NewEvent.Properties["ProcessName"].Value == SPELUNKY_PROCESS_NAME + ".exe")
+                    {
+                        spelunkyProcess = TryGetSpelunkyProcess();
+                        if (spelunkyProcess != null)// Should always be true
+                        {
+                            processFound(TryGetSpelunkyProcess());
+                            processCreationWatcher.Stop();
+                        }
+                    }
+                });
+                processCreationWatcher.Start();
+            }
+            catch (ManagementException)
+            // Thrown if the application doesn't have administrative rights, revert to slower method
+            {
+                Timer processSearchTimer = new Timer(PROCESS_SEARCH_INTERVAL_MS);
+                processSearchTimer.Elapsed += (sender, e) =>
+                {
+                    spelunkyProcess = TryGetSpelunkyProcess();
+                    if (spelunkyProcess != null)
+                    {
+                        processFound(spelunkyProcess);
+                        processSearchTimer.Stop();
+                    }
+                };
+                processSearchTimer.Start();
+            }
+        }
+
+        private static Process TryGetSpelunkyProcess()
         {
             Process[] matchingProcesses = Process.GetProcessesByName(SPELUNKY_PROCESS_NAME);
             if (matchingProcesses.Length > 0)


### PR DESCRIPTION
…ring a button press using two different methods.

The first method uses ManagementEventWatcher to detect when a process is created and checks if it's Spel2.exe. It's fast, but requires the app to be run as administrator for some reason, I couldn't get around this in any way. If it wasn't run as administrator this fails and the second method is used, where you use a Timer to check every 5 seconds if a Spel2 process exists.

For some reason my version of visual studio changed a bunch of files without my consent like some project settings and App.config, feel free to change or remove those, you surely know more about this than me.