### PR TITLE
Updated offsets for 1.25.0b

### DIFF
--- a/JesterCap/ProcessReader.cs
+++ b/JesterCap/ProcessReader.cs
@@ -12,7 +12,7 @@ namespace JesterCap
         private const int PROCESS_WM_READ = 0x0010;
 
         // These offsets need to be updated with each new version of Spelunky 2.
-        // Current as of 1.23.3 (2021-10-16)
+        // Current as of 1.25.0b (2021-11-16)
         private const int OFFSET_GAME_DATA = 0x22DB7F08;
         private const int OFFSET_SCORE = 0x22DC3884;
         private const int OFFSET_FRAME_COUNT = 0xEE4;      // the number of frames spent in the current level (unpaused)

--- a/JesterCap/ProcessReader.cs
+++ b/JesterCap/ProcessReader.cs
@@ -13,8 +13,8 @@ namespace JesterCap
 
         // These offsets need to be updated with each new version of Spelunky 2.
         // Current as of 1.23.3 (2021-10-16)
-        private const int OFFSET_GAME_DATA = 0x22DAFE48;
-        private const int OFFSET_SCORE = 0x22DBB604;
+        private const int OFFSET_GAME_DATA = 0x22DB7F08;
+        private const int OFFSET_SCORE = 0x22DC3884;
         private const int OFFSET_FRAME_COUNT = 0xEE4;      // the number of frames spent in the current level (unpaused)
         private const int OFFSET_NUM_ITEMS = 0X77E;        // the number of items picked up
         private const int OFFSET_FIRST_ITEM_ID = 0x784;    // the first item ID in memory


### PR DESCRIPTION
Only game data and score offsets changed last update. The score still doesn't show on the UI, but the timer works.